### PR TITLE
Add noxfile

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,18 +44,19 @@ Your new python package will have the following:
 
 - Standard `src/` layout
 - Declarative setup with `pyproject.toml` (following [PEP 621](https://peps.python.org/pep-0621/))
-- Reproducible tests with `pytest` and `tox`
-- Reproducible notebooks with [`treon`](https://github.com/reviewNB/treon) and `tox`
 - A command line interface with `click`
 - A vanity CLI via python entrypoints
-- Version management with `bump2version`
-- Documentation build with `sphinx`
-- Testing of code quality with `ruff` in `tox`
-- Testing of documentation coverage with `docstr-coverage` in `tox`
-- Testing of documentation format and build in `tox`
-- Testing of package metadata completeness with `pyroma` in `tox`
-- Testing of MANIFEST correctness with `check-manifest` in `tox`
-- Testing of optional static typing with `mypy` in `tox`
+- Reproducible workflows in either `tox` or `nox`
+  - Reproducible tests with `pytest` and 
+  - Reproducible notebooks with [`treon`](https://github.com/reviewNB/treon)
+  - Version management with `bump2version`
+  - Documentation build with `sphinx`
+  - Testing of code quality with `ruff`
+  - Testing of documentation coverage with `docstr-coverage`
+  - Testing of documentation format and build
+  - Testing of package metadata completeness with `pyroma`
+  - Testing of MANIFEST correctness with `check-manifest`
+  - Testing of optional static typing with `mypy`
 - A `py.typed` file so other packages can use your type hints
 - Automated running of tests on each push
   with [GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions)
@@ -64,7 +65,7 @@ Your new python package will have the following:
 - A pre-formatted README with badges
 - A pre-formatted LICENSE file with the MIT License (you can change this to whatever you want, though)
 - A pre-formatted CONTRIBUTING guide
-- Automatic tool for releasing to PyPI with `tox -e finish`
+- Automatic tool for releasing to PyPI with `tox -e finish`  (or `nox -s finish`)
 - A copy of the [Contributor Covenant](https://www.contributor-covenant.org/) as a basic code of conduct
 
 ## Attribution

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Your new python package will have the following:
 
 - Standard `src/` layout
 - Declarative setup with `pyproject.toml` (following [PEP 621](https://peps.python.org/pep-0621/))
-- Reproducible workflows configured with `tox`
+- Reproducible workflows configured with `tox` or `nox`
   - Reproducible tests with `pytest` and 
   - Reproducible notebooks with [`treon`](https://github.com/reviewNB/treon)
   - Documentation build with `sphinx`

--- a/README.md
+++ b/README.md
@@ -44,9 +44,7 @@ Your new python package will have the following:
 
 - Standard `src/` layout
 - Declarative setup with `pyproject.toml` (following [PEP 621](https://peps.python.org/pep-0621/))
-- A command line interface with `click`
-- A vanity CLI via python entrypoints
-- Reproducible workflows in either `tox` or `nox`
+- Reproducible workflows configured with `tox`
   - Reproducible tests with `pytest` and 
   - Reproducible notebooks with [`treon`](https://github.com/reviewNB/treon)
   - Version management with `bump2version`
@@ -57,6 +55,9 @@ Your new python package will have the following:
   - Testing of package metadata completeness with `pyroma`
   - Testing of MANIFEST correctness with `check-manifest`
   - Testing of optional static typing with `mypy`
+  - Automatic tool for releasing to PyPI
+- A command line interface with `click`
+- A vanity CLI via python entrypoints
 - A `py.typed` file so other packages can use your type hints
 - Automated running of tests on each push
   with [GitHub Actions](https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions)
@@ -65,7 +66,6 @@ Your new python package will have the following:
 - A pre-formatted README with badges
 - A pre-formatted LICENSE file with the MIT License (you can change this to whatever you want, though)
 - A pre-formatted CONTRIBUTING guide
-- Automatic tool for releasing to PyPI with `tox -e finish`  (or `nox -s finish`)
 - A copy of the [Contributor Covenant](https://www.contributor-covenant.org/) as a basic code of conduct
 
 ## Attribution

--- a/README.md
+++ b/README.md
@@ -47,15 +47,16 @@ Your new python package will have the following:
 - Reproducible workflows configured with `tox`
   - Reproducible tests with `pytest` and 
   - Reproducible notebooks with [`treon`](https://github.com/reviewNB/treon)
-  - Version management with `bump2version`
   - Documentation build with `sphinx`
   - Testing of code quality with `ruff`
   - Testing of documentation coverage with `docstr-coverage`
-  - Testing of documentation format and build
+  - Testing of documentation format
   - Testing of package metadata completeness with `pyroma`
   - Testing of MANIFEST correctness with `check-manifest`
   - Testing of optional static typing with `mypy`
-  - Automatic tool for releasing to PyPI
+  - Version management with `bump2version`
+  - Building with `build[uv]`
+  - Releasing to PyPI with `twine`
 - A command line interface with `click`
 - A vanity CLI via python entrypoints
 - A `py.typed` file so other packages can use your type hints

--- a/cookiecutter.json
+++ b/cookiecutter.json
@@ -14,5 +14,12 @@
     false,
     true
   ],
+  "runner": [
+    "tox",
+    "nox"
+  ],
+  "__runner": "{% if cookiecutter['runner'] == 'tox' %}tox -e{% else %}nox -s{% endif %}",
+  "__runner_pip": "{% if cookiecutter['runner'] == 'tox' %}tox tox-uv{% else %}nox[uv]{% endif %}",
+  "__runner_tests": "{% if cookiecutter['runner'] == 'tox' %}py{% else %}tests{% endif %}",
   "__gh_slug": "{{ cookiecutter.github_organization_name }}/{{ cookiecutter.github_repository_name }}"
 }

--- a/hooks/post_gen_project.py
+++ b/hooks/post_gen_project.py
@@ -17,3 +17,8 @@ if __name__ == "__main__":
 
     if "{{ cookiecutter.gitlab|lower }}" == "false":
         PROJECT_DIRECTORY.joinpath(".gitlab-ci.yml").unlink()
+
+    if "{{ cookiecutter.runner }}" == "tox":
+        PROJECT_DIRECTORY.joinpath("noxfile.py").unlink()
+    else:
+        PROJECT_DIRECTORY.joinpath("tox.ini").unlink()

--- a/{{cookiecutter.package_name}}/.github/CONTRIBUTING.md
+++ b/{{cookiecutter.package_name}}/.github/CONTRIBUTING.md
@@ -32,21 +32,21 @@ acceptance and merge into the main branch. This has several benefits:
 
 ### Code Style
 
-This project uses `tox` for running code quality checks. Start by installing
-`tox` and `tox-uv` with `pip install tox tox-uv`.
+This project uses `{{ cookiecutter.runner }}` for running code quality checks. Start by installing
+it` with `pip install {{ cookiecutter.__runner_pip }}`.
 
 This project encourages the use of optional static typing. It
 uses [`mypy`](http://mypy-lang.org/) as a type checker. You can check if
-your code passes `mypy` with `tox -e mypy`.
+your code passes `mypy` with `{{ cookecutter.__runner }} mypy`.
 
 This project uses [`ruff`](https://docs.astral.sh/ruff/) to automatically
 enforce a consistent code style. You can apply `ruff format` and other pre-configured
-formatters with `tox -e format`.
+formatters with `{{ cookecutter.__runner }} format`.
 
 This project uses [`ruff`](https://docs.astral.sh/ruff/) and several plugins for
 additional checks of documentation style, security issues, good variable
 nomenclature, and more (see `pyproject.toml` for a list of Ruff plugins). You can check if your
-code passes `ruff check` with `tox -e lint`.
+code passes `ruff check` with `{{ cookecutter.__runner }} lint`.
 
 Each of these checks are run on each commit using GitHub Actions as a continuous
 integration service. Passing all of them is required for accepting a
@@ -74,15 +74,15 @@ reports on functions that are not fully documented.
 
 This project uses [`sphinx`](https://www.sphinx-doc.org) to automatically build
 documentation into a narrative structure. You can check that the documentation
-builds properly in an isolated environment with `tox -e docs-test` and actually
-build it locally with `tox -e docs`.
+builds properly in an isolated environment with `{{ cookecutter.__runner }} docs-test` and actually
+build it locally with `{{ cookecutter.__runner }} docs`.
 
 ### Testing
 
 Functions in this repository should be unit tested. These can either be written
 using the `unittest` framework in the `tests/` directory or as embedded
-doctests. You can check that the unit tests pass with `tox -e py` and that the
-doctests pass with `tox -e doctests`. These tests are required to pass for
+doctests. You can check that the unit tests pass with `{{ cookecutter.__runner }} {{ cookiecutter.__runner_tests }}`
+and that the doctests pass with `{{ cookecutter.__runner }} doctests`. These tests are required to pass for
 accepting a contribution.
 
 ### Syncing your fork

--- a/{{cookiecutter.package_name}}/.github/CONTRIBUTING.md
+++ b/{{cookiecutter.package_name}}/.github/CONTRIBUTING.md
@@ -37,16 +37,16 @@ it` with `pip install {{ cookiecutter.__runner_pip }}`.
 
 This project encourages the use of optional static typing. It
 uses [`mypy`](http://mypy-lang.org/) as a type checker. You can check if
-your code passes `mypy` with `{{ cookecutter.__runner }} mypy`.
+your code passes `mypy` with `{{ cookiecutter.__runner }} mypy`.
 
 This project uses [`ruff`](https://docs.astral.sh/ruff/) to automatically
 enforce a consistent code style. You can apply `ruff format` and other pre-configured
-formatters with `{{ cookecutter.__runner }} format`.
+formatters with `{{ cookiecutter.__runner }} format`.
 
 This project uses [`ruff`](https://docs.astral.sh/ruff/) and several plugins for
 additional checks of documentation style, security issues, good variable
 nomenclature, and more (see `pyproject.toml` for a list of Ruff plugins). You can check if your
-code passes `ruff check` with `{{ cookecutter.__runner }} lint`.
+code passes `ruff check` with `{{ cookiecutter.__runner }} lint`.
 
 Each of these checks are run on each commit using GitHub Actions as a continuous
 integration service. Passing all of them is required for accepting a
@@ -74,15 +74,15 @@ reports on functions that are not fully documented.
 
 This project uses [`sphinx`](https://www.sphinx-doc.org) to automatically build
 documentation into a narrative structure. You can check that the documentation
-builds properly in an isolated environment with `{{ cookecutter.__runner }} docs-test` and actually
-build it locally with `{{ cookecutter.__runner }} docs`.
+builds properly in an isolated environment with `{{ cookiecutter.__runner }} docs-test` and actually
+build it locally with `{{ cookiecutter.__runner }} docs`.
 
 ### Testing
 
 Functions in this repository should be unit tested. These can either be written
 using the `unittest` framework in the `tests/` directory or as embedded
-doctests. You can check that the unit tests pass with `{{ cookecutter.__runner }} {{ cookiecutter.__runner_tests }}`
-and that the doctests pass with `{{ cookecutter.__runner }} doctests`. These tests are required to pass for
+doctests. You can check that the unit tests pass with `{{ cookiecutter.__runner }} {{ cookiecutter.__runner_tests }}`
+and that the doctests pass with `{{ cookiecutter.__runner }} doctests`. These tests are required to pass for
 accepting a contribution.
 
 ### Syncing your fork

--- a/{{cookiecutter.package_name}}/.github/workflows/tests.yml
+++ b/{{cookiecutter.package_name}}/.github/workflows/tests.yml
@@ -26,9 +26,9 @@ jobs:
           python-version: ${{ "{{" }} matrix.python-version {{ "}}" }}
       - name: Install dependencies
         run: |
-          pip install tox tox-uv
+          pip install {{ cookiecutter.__runner_pip }}
       - name: Run command
-        run: tox run -e ${{ "{{" }} matrix.tox-command {{ "}}" }}
+        run: {{ cookiecutter.__runner }} ${{ "{{" }} matrix.tox-command {{ "}}" }}
   docs:
     name: Documentation
     runs-on: ubuntu-latest
@@ -43,14 +43,14 @@ jobs:
           python-version: ${{ "{{" }} matrix.python-version {{ "}}" }}
       - name: Install dependencies
         run: |
-          pip install tox tox-uv
+          pip install {{ cookiecutter.__runner_pip }}
           sudo apt-get install graphviz
       - name: Check RST conformity with doc8
-        run: tox run -e doc8
+        run: {{ cookiecutter.__runner }} doc8
       - name: Check docstring coverage
-        run: tox run -e docstr-coverage
+        run: {{ cookiecutter.__runner }} docstr-coverage
       - name: Check documentation build with Sphinx
-        run: tox run -e docs-test
+        run: {{ cookiecutter.__runner }} docs-test
   tests:
     name: Tests
     runs-on: ${{ "{{" }} matrix.os {{ "}}" }}
@@ -65,10 +65,10 @@ jobs:
         with:
           python-version: ${{ "{{" }} matrix.python-version {{ "}}" }}
       - name: Install dependencies
-        run: pip install tox tox-uv
+        run: pip install {{ cookiecutter.__runner_pip }}
       - name: Test with pytest and generate coverage file
         run:
-          tox run -e py
+          {{ cookiecutter.__runner }} {{ cookiecutter.__runner_tests }}
       - name: Upload coverage report to codecov
         uses: codecov/codecov-action@v1
         if: success()

--- a/{{cookiecutter.package_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.package_name}}/.gitlab-ci.yml
@@ -6,59 +6,59 @@ stages:
 manifest:
   stage: qa
   script:
-    - pip install tox tox-uv
-    - tox -e manifest
+    - pip install {{ cookiecutter.__runner_pip }}
+    - install {{ cookiecutter.__runner }} manifest
 
 lint:
   stage: qa
   script:
-    - pip install tox tox-uv
-    - tox -e lint
+    - pip install {{ cookiecutter.__runner_pip }}
+    - install {{ cookiecutter.__runner }} lint
 
 pyroma:
   stage: qa
   script:
-    - pip install tox tox-uv
-    - tox -e pyroma
+    - pip install {{ cookiecutter.__runner_pip }}
+    - install {{ cookiecutter.__runner }} pyroma
 
 mypy:
   stage: qa
   script:
-    - pip install tox tox-uv
-    - tox -e mypy
+    - pip install {{ cookiecutter.__runner_pip }}
+    - install {{ cookiecutter.__runner }} mypy
 
 doc8:
   stage: docs
   script:
-    - pip install tox tox-uv
-    - tox -e doc8
+    - pip install {{ cookiecutter.__runner_pip }}
+    - install {{ cookiecutter.__runner }} doc8
 
 docstrs:
   stage: docs
   script:
-    - pip install tox tox-uv
-    - tox -e docstr-coverage
+    - pip install {{ cookiecutter.__runner_pip }}
+    - install {{ cookiecutter.__runner }} docstr-coverage
 
 docs:
   stage: docs
   script:
-    - pip install tox tox-uv
-    - tox -e docs
+    - pip install {{ cookiecutter.__runner_pip }}
+    - install {{ cookiecutter.__runner }} docs
 
 tests:
   stage: test
   script:
-    - pip install tox tox-uv
-    - tox -e py
+    - pip install {{ cookiecutter.__runner_pip }}
+    - install {{ cookiecutter.__runner }} {{ cookiecutter.__runner_tests }}
 
 doctests:
   stage: test
   script:
-    - pip install tox tox-uv
-    - tox -e doctests
+    - pip install {{ cookiecutter.__runner_pip }}
+    - install {{ cookiecutter.__runner }} doctests
 
 treon:
   stage: test
   script:
-    - pip install tox tox-uv
-    - tox -e treon
+    - pip install {{ cookiecutter.__runner_pip }}
+    - install {{ cookiecutter.__runner }} treon

--- a/{{cookiecutter.package_name}}/.gitlab-ci.yml
+++ b/{{cookiecutter.package_name}}/.gitlab-ci.yml
@@ -7,58 +7,58 @@ manifest:
   stage: qa
   script:
     - pip install {{ cookiecutter.__runner_pip }}
-    - install {{ cookiecutter.__runner }} manifest
+    - {{ cookiecutter.__runner }} manifest
 
 lint:
   stage: qa
   script:
     - pip install {{ cookiecutter.__runner_pip }}
-    - install {{ cookiecutter.__runner }} lint
+    - {{ cookiecutter.__runner }} lint
 
 pyroma:
   stage: qa
   script:
     - pip install {{ cookiecutter.__runner_pip }}
-    - install {{ cookiecutter.__runner }} pyroma
+    - {{ cookiecutter.__runner }} pyroma
 
 mypy:
   stage: qa
   script:
     - pip install {{ cookiecutter.__runner_pip }}
-    - install {{ cookiecutter.__runner }} mypy
+    - {{ cookiecutter.__runner }} mypy
 
 doc8:
   stage: docs
   script:
     - pip install {{ cookiecutter.__runner_pip }}
-    - install {{ cookiecutter.__runner }} doc8
+    - {{ cookiecutter.__runner }} doc8
 
 docstrs:
   stage: docs
   script:
     - pip install {{ cookiecutter.__runner_pip }}
-    - install {{ cookiecutter.__runner }} docstr-coverage
+    - {{ cookiecutter.__runner }} docstr-coverage
 
 docs:
   stage: docs
   script:
     - pip install {{ cookiecutter.__runner_pip }}
-    - install {{ cookiecutter.__runner }} docs
+    - {{ cookiecutter.__runner }} docs
 
 tests:
   stage: test
   script:
     - pip install {{ cookiecutter.__runner_pip }}
-    - install {{ cookiecutter.__runner }} {{ cookiecutter.__runner_tests }}
+    - {{ cookiecutter.__runner }} {{ cookiecutter.__runner_tests }}
 
 doctests:
   stage: test
   script:
     - pip install {{ cookiecutter.__runner_pip }}
-    - install {{ cookiecutter.__runner }} doctests
+    - {{ cookiecutter.__runner }} doctests
 
 treon:
   stage: test
   script:
     - pip install {{ cookiecutter.__runner_pip }}
-    - install {{ cookiecutter.__runner }} treon
+    - {{ cookiecutter.__runner }} treon

--- a/{{cookiecutter.package_name}}/MANIFEST.in
+++ b/{{cookiecutter.package_name}}/MANIFEST.in
@@ -8,4 +8,4 @@ prune docs
 global-exclude *.py[cod] __pycache__ *.so *.dylib .DS_Store *.gpickle .idea/**
 
 include README.md LICENSE
-exclude tox.ini .bumpversion.cfg .readthedocs.yml .cruft.json CITATION.cff docker-compose.yml Dockerfile
+exclude tox.ini .bumpversion.cfg .readthedocs.yml .cruft.json CITATION.cff docker-compose.yml Dockerfile noxfile.py

--- a/{{cookiecutter.package_name}}/README.md
+++ b/{{cookiecutter.package_name}}/README.md
@@ -50,7 +50,7 @@ be used from the shell with the `--help` flag to show all subcommands:
 {% endif %}
 ## 🚀 Installation
 
-<!-- Uncomment this section after your first ``tox -e finish``
+<!-- Uncomment this section after your first ``{{ cookiecutter.__runner }} finish``
 The most recent release can be installed from
 [PyPI](https://pypi.org/project/{{cookiecutter.package_name}}/) with:
 
@@ -141,11 +141,11 @@ available [here](https://github.com/cruft/cruft?tab=readme-ov-file#updating-a-pr
 
 ### 🥼 Testing
 
-After cloning the repository and installing `tox` and `tox-uv` with `pip install tox tox-uv`,
+After cloning the repository and installing `{{ cookiecutter.runner }}` with `pip install {{ cookiecutter.__runner_pip }}`, 
 the unit tests in the `tests/` folder can be run reproducibly with:
 
 ```shell
-tox
+{{ cookiecutter.__runner }} {{ cookiecutter.__runner_tests }}
 ```
 
 Additionally, these tests are automatically re-run with each commit in a
@@ -158,7 +158,7 @@ The documentation can be built locally using the following:
 ```shell
 git clone git+https://github.com/{{cookiecutter.github_organization_name}}/{{cookiecutter.github_repository_name}}.git
 cd {{cookiecutter.github_repository_name}}
-tox -e docs
+{{ cookiecutter.__runner }} docs
 open docs/build/html/index.html
 ``` 
 
@@ -171,7 +171,7 @@ The documentation can be deployed to [ReadTheDocs](https://readthedocs.io) using
 [this guide](https://docs.readthedocs.io/en/stable/intro/import-guide.html).
 The [`.readthedocs.yml`](.readthedocs.yml) YAML file contains all the configuration you'll need.
 You can also set up continuous integration on GitHub to check not only that
-Sphinx can build the documentation in an isolated environment (i.e., with ``tox -e docs-test``)
+Sphinx can build the documentation in an isolated environment (i.e., with ``{{ cookiecutter.__runner }} docs-test``)
 but also that [ReadTheDocs can build it too](https://docs.readthedocs.io/en/stable/pull-requests.html).
 
 #### Configuring ReadTheDocs
@@ -243,12 +243,12 @@ be found [here](https://packaging.python.org/en/latest/specifications/pypirc).
 
 #### Uploading to PyPI
 
-After installing the package in development mode and installing `tox` and `tox-uv` with `pip install tox tox-uv`,
-the commands for making a new release are contained within the `finish` environment
-in `tox.ini`. Run the following from the shell:
+After installing the package in development mode and installing
+`{{ cookiecutter.runner }}` with `pip install {{ cookiecutter.__runner_pip }}`,
+run the following from the shell:
 
 ```shell
-tox -e finish
+{{ cookiecutter.__runner }} finish
 ```
 
 This script does the following:

--- a/{{cookiecutter.package_name}}/docs/source/index.rst
+++ b/{{cookiecutter.package_name}}/docs/source/index.rst
@@ -9,17 +9,17 @@ It comes with the following:
 
 - Standard `src/` layout
 - Declarative setup with `pyproject.toml` (following [PEP 621](https://peps.python.org/pep-0621/))
-- Reproducible tests with `pytest` and `tox`{% if cookiecutter.command_line_interface|lower != "false" %}
+- Reproducible tests with `pytest` and `{{ cookecutter.runner }}`{% if cookiecutter.command_line_interface|lower != "false" %}
 - A command line interface with `click`{% endif %}
 - A vanity CLI via python entrypoints
 - Version management with `bumpversion`
 - Documentation build with `sphinx`
-- Testing of code quality with `ruff` in `tox`
-- Testing of documentation coverage with `docstr-coverage` in `tox`
-- Testing of documentation format and build in `tox`
-- Testing of package metadata completeness with `pyroma` in `tox`
-- Testing of MANIFEST correctness with `check-manifest` in `tox`
-- Testing of optional static typing with `mypy` in `tox`
+- Testing of code quality with `ruff` in `{{ cookiecutter.runner }}`
+- Testing of documentation coverage with `docstr-coverage` in `{{ cookecutter.runner }}`
+- Testing of documentation format and build in `{{ cookecutter.runner }}`
+- Testing of package metadata completeness with `pyroma` in `{{ cookecutter.runner }}`
+- Testing of MANIFEST correctness with `check-manifest` in `{{ cookecutter.runner }}`
+- Testing of optional static typing with `mypy` in `{{ cookecutter.runner }}`
 - A `py.typed` file so other packages can use your type hints
 - Automated running of tests on each push with GitHub Actions
 - Configuration for `ReadTheDocs <https://readthedocs.org/>`_
@@ -27,7 +27,7 @@ It comes with the following:
 - A pre-formatted README with badges
 - A pre-formatted LICENSE file with the MIT License (you can change this to whatever you want, though)
 - A pre-formatted CONTRIBUTING guide
-- Automatic tool for releasing to PyPI with ``tox -e finish``
+- Automatic tool for releasing to PyPI with ``{{ cookecutter.runner }} -e finish``
 - A copy of the `Contributor Covenant <https://www.contributor-covenant.org>`_ as a basic code of conduct
 
 Table of Contents

--- a/{{cookiecutter.package_name}}/docs/source/index.rst
+++ b/{{cookiecutter.package_name}}/docs/source/index.rst
@@ -7,27 +7,32 @@ This package was created with the `cookiecutter <https://github.com/cookiecutter
 package using `cookiecutter-snekpack <https://github.com/cthoyt/cookiecutter-snekpack>`_ template.
 It comes with the following:
 
-- Standard `src/` layout
-- Declarative setup with `pyproject.toml` (following [PEP 621](https://peps.python.org/pep-0621/))
-- Reproducible tests with `pytest` and `{{ cookecutter.runner }}`{% if cookiecutter.command_line_interface|lower != "false" %}
-- A command line interface with `click`{% endif %}
+- Standard ``src/`` layout
+- Declarative setup with `pyproject.toml` (following `PEP 621 <https://peps.python.org/pep-0621/>`_)
+- Reproducible workflows configured with ``{{ cookiecutter.runner }}``
+  - Reproducible tests with ``pytest``{% if cookiecutter.command_line_interface|lower != "false" %}
+  - A command line interface with ``click``{% endif %}
+  - Reproducible notebooks with `treon <https://github.com/reviewNB/treon>`_
+  - Documentation build with ``sphinx``
+  - Testing of code quality with ``ruff``
+  - Testing of documentation coverage with ``docstr-coverage``
+  - Testing of documentation format
+  - Testing of package metadata completeness with ``pyroma``
+  - Testing of MANIFEST correctness with ``check-manifest``
+  - Testing of optional static typing with ``mypy``
+  - Version management with ``bump2version``
+  - Building with ``build[uv]``
+  - Releasing to PyPI with ``twine``
+- A command line interface with ``click``
 - A vanity CLI via python entrypoints
-- Version management with `bumpversion`
-- Documentation build with `sphinx`
-- Testing of code quality with `ruff` in `{{ cookiecutter.runner }}`
-- Testing of documentation coverage with `docstr-coverage` in `{{ cookecutter.runner }}`
-- Testing of documentation format and build in `{{ cookecutter.runner }}`
-- Testing of package metadata completeness with `pyroma` in `{{ cookecutter.runner }}`
-- Testing of MANIFEST correctness with `check-manifest` in `{{ cookecutter.runner }}`
-- Testing of optional static typing with `mypy` in `{{ cookecutter.runner }}`
 - A `py.typed` file so other packages can use your type hints
-- Automated running of tests on each push with GitHub Actions
-- Configuration for `ReadTheDocs <https://readthedocs.org/>`_
+- Automated running of tests on each push
+  with `GitHub Actions <https://docs.github.com/en/actions/learn-github-actions/understanding-github-actions>`_
+- Configuration for `ReadTheDocs <https://readthedocs.org>`_
 - A good base `.gitignore` generated from `gitignore.io <https://gitignore.io>`_.
 - A pre-formatted README with badges
 - A pre-formatted LICENSE file with the MIT License (you can change this to whatever you want, though)
 - A pre-formatted CONTRIBUTING guide
-- Automatic tool for releasing to PyPI with ``{{ cookecutter.runner }} -e finish``
 - A copy of the `Contributor Covenant <https://www.contributor-covenant.org>`_ as a basic code of conduct
 
 Table of Contents

--- a/{{cookiecutter.package_name}}/noxfile.py
+++ b/{{cookiecutter.package_name}}/noxfile.py
@@ -85,7 +85,7 @@ def doc8(session: nox.Session):
     session.run("doc8", "docs/source/")
 
 
-@nox.session(tags=["docs"])
+@nox.session(name="docs-test", tags=["docs"])
 def docs_test(session: nox.Session):
     """Test building the documentation in an isolated environment."""
     session.install(".[docs]")

--- a/{{cookiecutter.package_name}}/noxfile.py
+++ b/{{cookiecutter.package_name}}/noxfile.py
@@ -144,14 +144,14 @@ def pyroma(session: nox.Session):
     session.run("pyroma", "--min=10", ".")
 
 
-@nox.session(tags=["dev"])
+@nox.session(tags=["dev"], default=False)
 def build(session: nox.Session):
     """Build the package."""
     session.install("wheel", "build[uv]", "setuptools")
     session.run("python", "-m", "build", "--sdist", "--wheel", "--no-isolation")
 
 
-@nox.session(tags=["dev"])
+@nox.session(tags=["dev"], default=False)
 def release(session: nox.Session):
     """Build a pip package."""
     build(session)
@@ -159,7 +159,7 @@ def release(session: nox.Session):
     session.run("python", "-m", "twine", "upload", "--skip-existing", "dist/*")
 
 
-@nox.session(tags=["dev"])
+@nox.session(tags=["dev"], default=False)
 def finish(session: nox.Session):
     """Finish this version increase the version number and upload to PyPI."""
     session.install("bump2version")
@@ -170,7 +170,7 @@ def finish(session: nox.Session):
     session.run("git", "push", external=True)
 
 
-@nox.session(tags=["dev"])
+@nox.session(tags=["dev"], default=False)
 def test_release(session: nox.Session):
     """Build a pip package."""
     build(session)
@@ -187,7 +187,7 @@ def test_release(session: nox.Session):
     )
 
 
-@nox.session(tags=["dev"])
+@nox.session(tags=["dev"], default=False)
 def test_finish(session: nox.Session):
     """Finish this version increase the version number and upload to PyPI."""
     session.install("bump2version")

--- a/{{cookiecutter.package_name}}/noxfile.py
+++ b/{{cookiecutter.package_name}}/noxfile.py
@@ -1,0 +1,133 @@
+"""Encode workflows with Nox.
+
+Note that Nox support is experimental for the cookiecutter-snekpack
+and is not up to feature parity as the Tox configuration.
+"""
+
+import nox
+
+from pathlib import Path
+
+nox.options.default_venv_backend = 'uv'
+
+HERE = Path(__file__).parent.resolve()
+
+
+@nox.session()
+def tests(session: nox.Session):
+    """Run unit and integration tests."""
+    session.install(".[tests]")
+    session.run("coverage", "run", "-p", "-m", "pytest", "--durations=20", "tests")
+    session.run("coverage", "combine")
+    session.run("coverage", "xml")
+
+
+@nox.session()
+def coverage_clean(session: nox.Session):
+    """Remove testing coverage artifacts."""
+    session.install("coverage")
+    session.run("coverage", "erase")
+
+
+@nox.session()
+def doctests(session: nox.Session):
+    """Test that documentation examples run properly."""
+    session.install(".")
+    session.install("xdoctest", "pygments")
+    session.run("xdoctest", "-m", "src/")
+
+
+@nox.session()
+def treon(session: nox.Session):
+    """Test that notebooks can run to completion."""
+    if not HERE.joinpath("notebooks").is_dir():
+        return
+    session.install(".")
+    session.install("treon")
+    session.install("treon", "notebooks/")
+
+
+@nox.session()
+def format(session: nox.Session):
+    """Format the code in a deterministic way using ruff."""
+    session.install("ruff")
+    session.run("ruff", "check", "--fix")
+    session.run("ruff", "format")
+
+
+@nox.session()
+def lint(session: nox.Session):
+    """Check code quality using ruff and other tools."""
+    session.install("ruff", "darglint2")
+    session.run("ruff", "check")
+    session.run(
+        "darglint2",
+        "--strictness",
+        "short",
+        "--docstring-style",
+        "sphinx",
+        "-v",
+        "2",
+        "src/",
+        "tests/",
+        "notebooks/",
+    )
+
+
+@nox.session()
+def doc8(session: nox.Session):
+    """Run the doc8 tool to check the style of the RST files in the project docs."""
+    session.install("sphinx", "doc8")
+    session.run("doc8", "docs/source/")
+
+
+@nox.session()
+def docs_test(session: nox.Session):
+    """Test building the documentation in an isolated environment."""
+    session.install(".[docs]")
+    session.chdir("docs")
+
+    directory = Path(session.create_tmp())
+    source = directory / "source"
+
+    session.run("cp", "-r", "source", source, external=True)
+    session.run(
+        "python",
+        "-m",
+        "sphinx",
+        "-W",  # Warnings are considered as errors via -W
+        "-b",
+        "html",
+        "-d",
+        directory / "build" / "doctrees",
+        source,
+        directory / "build" / "html",
+    )
+
+
+@nox.session()
+def docstr_coverage(session: nox.Session):
+    """Run the docstr-coverage tool to check documentation coverage."""
+    session.install("docstr-coverage")
+    session.run("docstr-coverage", "src/", "tests/", "--skip-private", "--skip-magic")
+
+
+@nox.session()
+def manifest(session: nox.Session):
+    """Check that the MANIFEST.in is written properly and give feedback on how to fix it."""
+    session.install("check-manifest")
+    session.run("check-manifest")
+
+
+@nox.session()
+def mypy(session: nox.Session):
+    """Run the mypy tool to check static typing on the project."""
+    session.install("mypy", "pydantic")
+    session.run("mypy", "--install-types", "--non-interactive", "--ignore-missing-imports", "src/")
+
+
+@nox.session()
+def pyroma(session: nox.Session):
+    """Run the pyroma tool to check the package friendliness of the project."""
+    session.install("pygments", "pyroma")
+    session.run("pyroma", "--min=10", ".")

--- a/{{cookiecutter.package_name}}/noxfile.py
+++ b/{{cookiecutter.package_name}}/noxfile.py
@@ -12,7 +12,8 @@ import nox
 
 from pathlib import Path
 
-nox.options.default_venv_backend = "uv"
+# see https://nox.thea.codes/en/stable/usage.html#changing-the-sessions-default-backend
+nox.options.default_venv_backend = "uv|virtualenv"
 
 HERE = Path(__file__).parent.resolve()
 

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -137,7 +137,7 @@ omit = [
 [tool.coverage.paths]
 source = [
     "src/{{cookiecutter.package_name}}",
-    ".tox/*/lib/python*/site-packages/{{cookiecutter.package_name}}",
+    ".{{ cookiecutter.runner }}/*/lib/python*/site-packages/{{cookiecutter.package_name}}",
 ]
 
 [tool.coverage.report]

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -24,7 +24,11 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Framework :: Pytest",
+    {% if cookiecutter.runner == "tox"}
     "Framework :: tox",
+    {% else %}
+    # note that there is currently no Trove classifier for Nox
+    {% endif %}
     "Framework :: Sphinx",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3.9",

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -24,7 +24,7 @@ classifiers = [
     "License :: OSI Approved :: MIT License",
     "Operating System :: OS Independent",
     "Framework :: Pytest",
-    {% if cookiecutter.runner == "tox"}
+    {% if cookiecutter.runner == "tox" %}
     "Framework :: tox",
     {% else %}
     # note that there is currently no Trove classifier for Nox


### PR DESCRIPTION
This PR adds a noxfile to the cookiecutter template. It might go as far as to give options on whether you want CI to run with nox or tox.

@v0lta are there any missing bits? can you let me know if this looks alright? I used https://github.com/v0lta/PyTorch-Wavelet-Toolbox/blob/main/noxfile.py as inspiration for this
