### PR TITLE
Implement dependency groups

### DIFF
--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -62,7 +62,7 @@ dependencies = [
 # see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#dependencies-optional-dependencies
 # [project.optional-dependencies]
 
-#
+# see https://peps.python.org/pep-0735/ and https://docs.astral.sh/uv/concepts/dependencies/#dependency-groups
 [dependency-groups]
 tests = [
     "pytest",

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -92,7 +92,7 @@ doc8 = [
 ]
 rstfmt = [
     {include-group = "docs"},
-    "rstfmt"
+    "rstfmt",
 ]
 doctests = [
     "xdoctest",
@@ -102,6 +102,21 @@ pyroma = [
     "pyroma",
     "pygments",
 ]
+bump = [
+    "bump-my-version",
+]
+build = [
+    "uv",
+    "setuptools",
+]
+release = [
+    {include-group = "build"},
+    "twine",
+]
+manifest = [
+    "check-manifest",
+]
+
 
 # See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls
 [project.urls]

--- a/{{cookiecutter.package_name}}/pyproject.toml
+++ b/{{cookiecutter.package_name}}/pyproject.toml
@@ -59,10 +59,21 @@ dependencies = [
     {% endif %}
 ]
 
-[project.optional-dependencies]
+# see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#dependencies-optional-dependencies
+# [project.optional-dependencies]
+
+#
+[dependency-groups]
 tests = [
     "pytest",
     "coverage",
+]
+lint = [
+    "ruff",
+]
+typing = [
+    "mypy",
+    "pydantic",
 ]
 docs = [
     "sphinx>=8",
@@ -74,6 +85,22 @@ docs = [
     # To include LaTeX comments easily in your docs.
     # If you uncomment this, don't forget to do the same in docs/conf.py
     # texext
+]
+doc8 = [
+    {include-group = "docs"},
+    "doc8",
+]
+rstfmt = [
+    {include-group = "docs"},
+    "rstfmt"
+]
+doctests = [
+    "xdoctest",
+    "pygments",
+]
+pyroma = [
+    "pyroma",
+    "pygments",
 ]
 
 # See https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -39,7 +39,8 @@ commands =
     coverage combine
     coverage xml
 # See the [dependency-groups] entry in pyproject.toml for "tests"
-dependency-groups = tests
+dependency-groups =
+    tests
 
 [testenv:coverage-clean]
 description = Remove testing coverage artifacts.
@@ -51,7 +52,8 @@ commands = coverage erase
 description = Test that documentation examples run properly.
 commands =
     xdoctest -m src
-dependency-groups = doctests
+dependency-groups =
+    doctests
 
 [testenv:treon]
 description = Test that notebooks can run to completion
@@ -62,7 +64,8 @@ deps =
 
 [testenv:format]
 description = Format the code in a deterministic way using ruff. Note that ruff check should come before ruff format when using --fix (ref: https://github.com/astral-sh/ruff-pre-commit/blob/main/README.md)
-dependency-groups = lint
+dependency-groups =
+    lint
 skip_install = true
 commands =
     ruff check --fix
@@ -73,13 +76,15 @@ commands =
 # or any other extension that adds extra directives
 description = Run documentation linters.
 # See the [dependency-groups] entry in pyproject.toml for "rstfmt"
-dependency-groups = rstfmt
+dependency-groups =
+    rstfmt
 skip_install = true
 commands =
     rstfmt docs/source/
 
 [testenv:manifest]
-deps = check-manifest
+dependency-groups =
+    manifest
 skip_install = true
 commands = check-manifest
 description = Check that the MANIFEST.in is written properly and give feedback on how to fix it.
@@ -87,26 +92,30 @@ description = Check that the MANIFEST.in is written properly and give feedback o
 [testenv:lint]
 description = Check code quality using ruff and other tools.
 skip_install = true
-dependency-groups = lint
+dependency-groups =
+    lint
 commands =
     ruff check
     ruff format --check
 
 [testenv:pyroma]
-dependency-groups = pyroma
+dependency-groups =
+    pyroma
 skip_install = true
 commands = pyroma --min=10 .
 description = Run the pyroma tool to check the package friendliness of the project.
 
 [testenv:mypy]
 description = Run the mypy tool to check static typing on the project.
-dependency-groups = typing
+dependency-groups =
+    typing
 skip_install = true
 commands = mypy --install-types --non-interactive --ignore-missing-imports --strict src/
 
 [testenv:doc8]
 skip_install = true
-dependency-groups = doc8
+dependency-groups =
+    doc8
 commands =
     doc8 docs/source/
 description = Run the doc8 tool to check the style of the RST files in the project docs.
@@ -121,8 +130,8 @@ commands =
 
 [testenv:docs]
 description = Build the documentation locally, allowing warnings.
-extras =
-    # See the [project.optional-dependencies] entry in pyproject.toml for "docs"
+dependency-groups =
+    # See the [dependency-groups] entry in pyproject.toml for "docs"
     docs
     # You might need to add additional extras if your documentation covers it
 commands =
@@ -131,8 +140,8 @@ commands =
 [testenv:docs-test]
 description = Test building the documentation in an isolated environment. Warnings are considered as errors via -W.
 changedir = docs
-extras =
-    {[testenv:docs]extras}
+dependency-groups =
+    {[testenv:docs]dependency-groups}
 commands =
     mkdir -p {envtmpdir}
     cp -r source {envtmpdir}/source
@@ -162,22 +171,21 @@ description = Bump the version number
 commands = bump-my-version bump {posargs}
 skip_install = true
 passenv = HOME
-deps =
-    bump-my-version
+dependency-groups =
+    bump
 
 [testenv:bumpversion-release]
 description = Remove the -dev tag from the version
 commands = bump-my-version bump release --tag
 skip_install = true
 passenv = HOME
-deps =
-    bump-my-version
+dependency-groups =
+    bump
 
 [testenv:build]
 skip_install = true
-deps =
-    uv
-    setuptools
+dependency-groups =
+    build
 commands =
     uv build --sdist --wheel --no-build-isolation
 
@@ -214,9 +222,8 @@ skip_install = true
 passenv =
     TWINE_USERNAME
     TWINE_PASSWORD
-deps =
-    {[testenv:build]deps}
-    twine >= 1.5.0
+dependency-groups =
+    release
 commands =
     {[testenv:build]commands}
     twine upload --skip-existing dist/*
@@ -230,9 +237,9 @@ passenv =
     HOME
     TWINE_USERNAME
     TWINE_PASSWORD
-deps =
-    {[testenv:release]deps}
-    bump-my-version
+dependency-groups =
+    bump
+    release
 commands =
     {[testenv:bumpversion-release]commands}
     {[testenv:release]commands}
@@ -276,9 +283,8 @@ skip_install = true
 passenv =
     TWINE_USERNAME
     TWINE_PASSWORD
-deps =
-    {[testenv:build]deps}
-    twine >= 1.5.0
+dependency-groups =
+    release
 commands =
     {[testenv:build]commands}
     twine upload --skip-existing --repository testpypi dist/*
@@ -292,9 +298,9 @@ passenv =
     HOME
     TWINE_USERNAME
     TWINE_PASSWORD
-deps =
-    {[testenv:testrelease]deps}
-    bump-my-version
+dependency-groups =
+    bump
+    release
 commands =
     {[testenv:bumpversion-release]commands}
     {[testenv:testrelease]commands}

--- a/{{cookiecutter.package_name}}/tox.ini
+++ b/{{cookiecutter.package_name}}/tox.ini
@@ -38,9 +38,8 @@ commands =
     coverage run -p -m pytest --durations=20 {posargs:tests}
     coverage combine
     coverage xml
-extras =
-    # See the [project.optional-dependencies] entry in pyproject.toml for "tests"
-    tests
+# See the [dependency-groups] entry in pyproject.toml for "tests"
+dependency-groups = tests
 
 [testenv:coverage-clean]
 description = Remove testing coverage artifacts.
@@ -52,9 +51,7 @@ commands = coverage erase
 description = Test that documentation examples run properly.
 commands =
     xdoctest -m src
-deps =
-    xdoctest
-    pygments
+dependency-groups = doctests
 
 [testenv:treon]
 description = Test that notebooks can run to completion
@@ -65,22 +62,18 @@ deps =
 
 [testenv:format]
 description = Format the code in a deterministic way using ruff. Note that ruff check should come before ruff format when using --fix (ref: https://github.com/astral-sh/ruff-pre-commit/blob/main/README.md)
-deps =
-    ruff
+dependency-groups = lint
 skip_install = true
 commands =
     ruff check --fix
     ruff format
 
 [testenv:format-docs]
-description = Run documentation linters.
 # note that this doesn't work with sphinx-click
 # or any other extension that adds extra directives
-deps =
-    rstfmt
-extras =
-    # See the [project.optional-dependencies] entry in pyproject.toml for "docs"
-    docs
+description = Run documentation linters.
+# See the [dependency-groups] entry in pyproject.toml for "rstfmt"
+dependency-groups = rstfmt
 skip_install = true
 commands =
     rstfmt docs/source/
@@ -93,36 +86,27 @@ description = Check that the MANIFEST.in is written properly and give feedback o
 
 [testenv:lint]
 description = Check code quality using ruff and other tools.
-
 skip_install = true
-deps =
-    ruff
+dependency-groups = lint
 commands =
     ruff check
     ruff format --check
 
 [testenv:pyroma]
-deps =
-    pygments
-    pyroma
+dependency-groups = pyroma
 skip_install = true
 commands = pyroma --min=10 .
 description = Run the pyroma tool to check the package friendliness of the project.
 
 [testenv:mypy]
 description = Run the mypy tool to check static typing on the project.
-deps =
-    mypy
-    pydantic
+dependency-groups = typing
 skip_install = true
 commands = mypy --install-types --non-interactive --ignore-missing-imports --strict src/
 
 [testenv:doc8]
 skip_install = true
-deps =
-    doc8
-extras =
-    docs
+dependency-groups = doc8
 commands =
     doc8 docs/source/
 description = Run the doc8 tool to check the style of the RST files in the project docs.


### PR DESCRIPTION
This PR switches from using optional-dependencies to dependency-groups for several development dependencies

This depends on:

- https://github.com/tox-dev/tox/pull/3409
- https://github.com/astral-sh/uv/pull/8272