### PR TITLE
Enforce standardized package and repo nomenclature

### DIFF
--- a/hooks/pre_gen_project.py
+++ b/hooks/pre_gen_project.py
@@ -8,13 +8,25 @@ Adapted from https://github.com/audreyfeldroy/cookiecutter-pypackage/blob/master
 import re
 import sys
 
-MODULE_REGEX = re.compile(r"^[_a-zA-Z][_a-zA-Z0-9]+$")
+PYTHON_PACKAGE_NAME_REGEX = re.compile(r"^[a-z][_a-z0-9]+$")
+REPOSITORY_REGEX = re.compile(r"^[a-zA-Z][-a-zA-Z0-9]+$")
 
-module_name = "{{ cookiecutter.package_name}}"
+python_package_name = "{{ cookiecutter.package_name}}"
+repository_name = "{{ cookiecutter.github_repository_name }}"
 
-if not MODULE_REGEX.match(module_name):
+if not PYTHON_PACKAGE_NAME_REGEX.match(python_package_name):
     print(
-        f"ERROR: {module_name} is not a valid Python module name. Please do not use a - and use _ instead"
+        f"ERROR: {python_package_name} is not a valid Python package name. "
+        "Please use lowercase only, do not use - and use _ instead."
+    )
+
+    # Exit to cancel project
+    sys.exit(1)
+
+if not REPOSITORY_REGEX.match(python_package_name):
+    print(
+        f"ERROR: {repository_name} is not a good version control repository name. "
+        f"Please do not use _ and use - instead."
     )
 
     # Exit to cancel project


### PR DESCRIPTION
Closes #18

1. Python package names should be all lowercase and not include dashes
2. Github repositories should include dashes nad not underscores