### PR TITLE
Update developer section on readme

### DIFF
--- a/{{cookiecutter.package_name}}/README.md
+++ b/{{cookiecutter.package_name}}/README.md
@@ -153,20 +153,6 @@ Alternatively, install using pip:
 $ python3 -m pip install -e .
 ```
 
-### Updating Package Boilerplate
-
-This project uses `cruft` to keep boilerplate (i.e., configuration, contribution
-guidelines, documentation configuration) up-to-date with the upstream
-cookiecutter package. Install cruft with either `uv tool install cruft` or
-`python3 -m pip install cruft` then run:
-
-```console
-$ cruft update
-```
-
-More info on Cruft's update command is available
-[here](https://github.com/cruft/cruft?tab=readme-ov-file#updating-a-project).
-
 ### 🥼 Testing
 
 After cloning the repository and installing `{{ cookiecutter.runner }}` with
@@ -205,7 +191,19 @@ only that Sphinx can build the documentation in an isolated environment (i.e.,
 with `{{ cookiecutter.__runner }} docs-test`) but also that
 [ReadTheDocs can build it too](https://docs.readthedocs.io/en/stable/pull-requests.html).
 
+</details>
+
+## For Maintainers
+
+<details>
+  <summary>See maintainer instructions</summary>
+
+### Initial Configuration
+
 #### Configuring ReadTheDocs
+
+[ReadTheDocs](https://readthedocs.org) is an external documentation hosting service
+that integrates with GitHub's CI/CD.
 
 1. Log in to ReadTheDocs with your GitHub account to install the integration at
    https://readthedocs.org/accounts/login/?next=/dashboard/
@@ -215,9 +213,7 @@ with `{{ cookiecutter.__runner }} docs-test`) but also that
    (i.e., with spaces and capital letters)
 4. Click next, and you're good to go!
 
-### 📦 Making a Release
-
-#### Configuring Zenodo
+#### Configuring Archival on Zenodo
 
 [Zenodo](https://zenodo.org) is a long-term archival system that assigns a DOI
 to each release of your package.
@@ -240,10 +236,10 @@ to see the DOI for the release and link to the Zenodo record for it.
 
 #### Registering with the Python Package Index (PyPI)
 
-You only have to do the following steps once.
+The [Python Package Index (PyPI)](https://pypi.org) hosts packages so they
+can be easily installed with `pip`, `uv`, and equivalent tools.
 
-1. Register for an account on the
-   [Python Package Index (PyPI)](https://pypi.org/account/register)
+1. Register for an account [here](https://pypi.org/account/register)
 2. Navigate to https://pypi.org/manage/account and make sure you have verified
    your email address. A verification email might not have been sent by default,
    so you might have to click the "options" dropdown next to your address to get
@@ -265,6 +261,8 @@ $ keyring set https://test.pypi.org/legacy/ __token__
 ```
 
 Note that this deprecates previous workflows using `.pypirc`.
+
+### 📦 Making a Release
 
 #### Uploading to PyPI
 
@@ -303,5 +301,19 @@ This script does the following:
 4. Click the big green "Publish Release" button
 
 This will trigger Zenodo to assign a DOI to your release as well.
+
+### Updating Package Boilerplate
+
+This project uses `cruft` to keep boilerplate (i.e., configuration, contribution
+guidelines, documentation configuration) up-to-date with the upstream
+cookiecutter package. Install cruft with either `uv tool install cruft` or
+`python3 -m pip install cruft` then run:
+
+```console
+$ cruft update
+```
+
+More info on Cruft's update command is available
+[here](https://github.com/cruft/cruft?tab=readme-ov-file#updating-a-project).
 
 </details>


### PR DESCRIPTION
Motivated by https://github.com/y0-causal-inference/y0/issues/301. This PR splits out developer and maintainer documentation on the README. It also better makes clear what is one-time setup and what is something that happens frequently